### PR TITLE
96 locales and customization

### DIFF
--- a/src/draw.js
+++ b/src/draw.js
@@ -1,3 +1,79 @@
+var defaultParams = {
+  locale: "en",
+  month_font: "Bebas Neue Light",
+  month_font_weight: "100",
+  external_css: ""
+};
+
+var userParams = {};
+if (document.location.search.length > 0) {
+  document.location.search
+    .substr(1)
+    .split("&")
+    .forEach(function (pair) {
+      var params = pair
+        .replace(/\+/g, "%20")
+        .split("=")
+        .map(decodeURIComponent);
+      userParams[params[0]] = params[1];
+    });
+}
+
+var params = {};
+
+// set params and populate form
+Object.keys(defaultParams).forEach(function (param) {
+  params[param] = userParams[param] || defaultParams[param];
+  document.getElementById(param).value = params[param];
+});
+
+var drawImmediately = true;
+
+// load external css
+if (params.external_css !== "") {
+  drawImmediately = false;
+  var link = document.createElement("link");
+  link.addEventListener("load", function () {
+    setTimeout(function () {
+      draw();
+    }, 1000);
+  }, false);
+  link.setAttribute("href", params.external_css);
+  link.setAttribute("rel", "stylesheet");
+  link.setAttribute("type", "text/css");
+  document.head.appendChild(link);
+}
+
+// set locale
+document.body.setAttribute('lang', params.locale);
+moment.locale(params.locale);
+
+// kerning data
+var monthKerning = {
+  "Bebas Neue Light": {
+    "en": [
+      "0 0 0 1.55 -0.85000008 0 -2.4299998",
+      "0 0 0 0 0 -0.95000011 -0.54999995 -0.98999995",
+      "",
+      "0 0 0 2.1899998 2.1399999",
+      "0 0 -4.4199996",
+      "",
+      "0 1.7300001 1.1800001 -8.46",
+      "0 0 0 0 0 -2.5899997",
+      "0 0 0 -3.1299989 -1.4000001 1.2 1.2299999",
+      "0 0 -2.0999999 -3.4299994",
+      "0 0 -2.1399999 -1.42 -0.75000006 1",
+      "0 0 -1.42 -1.2900001 0 1.33"
+    ]
+  }
+};
+
+var chosenKerning = [];
+
+if (monthKerning[fontFamilyMonth] && monthKerning[fontFamilyMonth][params.locale]) {
+  chosenKerning = monthKerning[fontFamilyMonth][params.locale];
+}
+
 //Changable variables
 //relative to size
 var svg_size = [2104.72, 2979.92],
@@ -38,8 +114,8 @@ var dateSeparator = 0.0002*svg_size[0];
 //var fontFamily = "msam10";
 //font-family: 'Sorren Ex Bold'
 //font-family: 'Sorren Ex Medium'
-var fontFamilyMonth = "Bebas Neue Light";
-var fontFamilyMonthWeight = "100";
+var fontFamilyMonth = params.month_font;
+var fontFamilyMonthWeight = params.month_font_weight;
 var monthes_font_size = 2.5*svg_size[1]/150;
 //var monthes_radius = R*0.78;
 var monthes_radius = R;
@@ -262,7 +338,7 @@ function draw(){
         date: dateString, 
         weekend: isWeekend, 
         month: dateFormatMonth(d),
-        monthName: dateFormatMonthName(d),
+        monthName: moment(d).format('MMMM'),
         color: "red", //tmp
       };
     });
@@ -274,20 +350,6 @@ function draw(){
   });
 
   var previousLen = 0;
-  monthKerning = [
-    "0 0 0 1.55 -0.85000008 0 -2.4299998",
-    "0 0 0 0 0 -0.95000011 -0.54999995 -0.98999995",
-    "",
-    "0 0 0 2.1899998 2.1399999",
-    "0 0 -4.4199996",
-    "",
-    "0 1.7300001 1.1800001 -8.46",
-    "0 0 0 0 0 -2.5899997",
-    "0 0 0 -3.1299989 -1.4000001 1.2 1.2299999",
-    "0 0 -2.0999999 -3.4299994",
-    "0 0 -2.1399999 -1.42 -0.75000006 1",
-    "0 0 -1.42 -1.2900001 0 1.33"
-    ];
   var monthes = d3.nest()
   .key(function(d){ return d.month; })
   .entries(dates)
@@ -301,7 +363,7 @@ function draw(){
       previousLenRelative: pLen / dates.length,
       color: color,
       values: d.values,
-      dx: monthKerning.shift(),
+      dx: chosenKerning.shift() || "",
     }; 
   });
 
@@ -646,4 +708,6 @@ function draw(){
     //});
 }
 
-draw();
+if (drawImmediately) {
+  draw();
+}

--- a/src/index.html
+++ b/src/index.html
@@ -1,8 +1,432 @@
 <html>
 <head>
+<meta charset="utf-8">
+<style type="text/css">
+.customizer {
+  font-family: Arial, sans-serif;
+}
+
+.customizer label {
+  color: #fff;
+}
+
+@media print {
+  .customizer {
+    display: none;
+  }
+}
+</style>
 <script src="http://d3js.org/d3.v3.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.6/moment-with-locales.min.js"></script>
 </head>
 <body style="background: teal;">
+<form id="customizer" class="customizer" method="GET">
+  <label for="locale">Locale</label>
+  <select name="locale" id="locale">  
+    <option value="af">
+      Afrikaans
+    </option>
+  
+    <option value="sq">
+      Albanian
+    </option>
+  
+    <option value="ar">
+      Arabic
+    </option>
+  
+    <option value="ar-ma">
+      Arabic (Morocco)
+    </option>
+  
+    <option value="ar-sa">
+      Arabic (Saudi Arabia)
+    </option>
+  
+    <option value="ar-tn">
+      Arabic (Tunisia)
+    </option>
+  
+    <option value="hy-am">
+      Armenian
+    </option>
+  
+    <option value="az">
+      Azerbaijani
+    </option>
+  
+    <option value="id">
+      Bahasa Indonesia
+    </option>
+  
+    <option value="ms-my">
+      Bahasa Melayu (Malaysia)
+    </option>
+  
+    <option value="eu">
+      Basque
+    </option>
+  
+    <option value="be">
+      Belarusian
+    </option>
+  
+    <option value="bn">
+      Bengali
+    </option>
+  
+    <option value="bs">
+      Bosnian
+    </option>
+  
+    <option value="br">
+      Breton
+    </option>
+  
+    <option value="bg">
+      Bulgarian
+    </option>
+  
+    <option value="my">
+      Burmese
+    </option>
+  
+    <option value="ca">
+      Catalan
+    </option>
+  
+    <option value="zh-cn">
+      Chinese (Simplified)
+    </option>
+  
+    <option value="zh-tw">
+      Chinese (Traditional)
+    </option>
+  
+    <option value="cv">
+      Chuvash
+    </option>
+  
+    <option value="hr">
+      Croatian
+    </option>
+  
+    <option value="cs">
+      Czech
+    </option>
+  
+    <option value="da">
+      Danish
+    </option>
+  
+    <option value="nl">
+      Dutch
+    </option>
+  
+    <option value="en-au">
+      English (Australia)
+    </option>
+  
+    <option value="en-ca">
+      English (Canada)
+    </option>
+  
+    <option value="en-ie">
+      English (Ireland)
+    </option>
+  
+    <option value="en-nz">
+      English (New Zealand)
+    </option>
+  
+    <option value="en-gb">
+      English (United Kingdom)
+    </option>
+  
+    <option value="en">
+      English (United States)
+    </option>
+  
+    <option value="eo">
+      Esperanto
+    </option>
+  
+    <option value="et">
+      Estonian
+    </option>
+  
+    <option value="fo">
+      Farose
+    </option>
+  
+    <option value="fi">
+      Finnish
+    </option>
+  
+    <option value="fr">
+      French
+    </option>
+  
+    <option value="fr-ca">
+      French (Canada)
+    </option>
+  
+    <option value="fr-ch">
+      French (Switzerland)
+    </option>
+  
+    <option value="fy">
+      Frisian
+    </option>
+  
+    <option value="gl">
+      Galician
+    </option>
+  
+    <option value="ka">
+      Georgian
+    </option>
+  
+    <option value="de">
+      German
+    </option>
+  
+    <option value="de-at">
+      German (Austria)
+    </option>
+  
+    <option value="el">
+      Greek
+    </option>
+  
+    <option value="he">
+      Hebrew
+    </option>
+  
+    <option value="hi">
+      Hindi
+    </option>
+  
+    <option value="hu">
+      Hungarian
+    </option>
+  
+    <option value="is">
+      Icelandic
+    </option>
+  
+    <option value="it">
+      Italian
+    </option>
+  
+    <option value="ja">
+      Japanese
+    </option>
+  
+    <option value="jv">
+      Javanese
+    </option>
+  
+    <option value="kk">
+      Kazakh
+    </option>
+  
+    <option value="km">
+      Khmer (Cambodia)
+    </option>
+  
+    <option value="tlh">
+      Klingon
+    </option>
+  
+    <option value="ko">
+      Korean
+    </option>
+  
+    <option value="lo">
+      Lao
+    </option>
+  
+    <option value="lv">
+      Latvian
+    </option>
+  
+    <option value="lt">
+      Lithuanian
+    </option>
+  
+    <option value="lb">
+      Luxembourgish
+    </option>
+  
+    <option value="mk">
+      Macedonian
+    </option>
+  
+    <option value="ml">
+      Malayalam
+    </option>
+  
+    <option value="dv">
+      Maldivian
+    </option>
+  
+    <option value="mr">
+      Marathi
+    </option>
+  
+    <option value="me">
+      Montenegrin
+    </option>
+  
+    <option value="ne">
+      Nepalese
+    </option>
+  
+    <option value="se">
+      Northern Sami
+    </option>
+  
+    <option value="nb">
+      Norwegian
+    </option>
+  
+    <option value="nn">
+      Norwegian Nynorsk
+    </option>
+  
+    <option value="fa">
+      Persian
+    </option>
+  
+    <option value="pl">
+      Polish
+    </option>
+  
+    <option value="pt">
+      Portuguese
+    </option>
+  
+    <option value="pt-br">
+      Portuguese (Brazil)
+    </option>
+  
+    <option value="ro">
+      Romanian
+    </option>
+  
+    <option value="ru">
+      Russian
+    </option>
+  
+    <option value="gd">
+      Scottish Gaelic
+    </option>
+  
+    <option value="sr">
+      Serbian
+    </option>
+  
+    <option value="sr-cyrl">
+      Serbian Cyrillic
+    </option>
+  
+    <option value="si">
+      Sinhalese
+    </option>
+  
+    <option value="sk">
+      Slovak
+    </option>
+  
+    <option value="sl">
+      Slovenian
+    </option>
+  
+    <option value="es">
+      Spanish
+    </option>
+  
+    <option value="sw">
+      Swahili
+    </option>
+  
+    <option value="sv">
+      Swedish
+    </option>
+  
+    <option value="tl-ph">
+      Tagalog (Filipino)
+    </option>
+  
+    <option value="tzl">
+      Talossan
+    </option>
+  
+    <option value="tzm">
+      Tamaziɣt
+    </option>
+  
+    <option value="tzm-latn">
+      Tamaziɣt Latin
+    </option>
+  
+    <option value="ta">
+      Tamil
+    </option>
+  
+    <option value="te">
+      Tegulu
+    </option>
+  
+    <option value="th">
+      Thai
+    </option>
+  
+    <option value="bo">
+      Tibetan
+    </option>
+  
+    <option value="tr">
+      Turkish
+    </option>
+  
+    <option value="uk">
+      Ukrainian
+    </option>
+  
+    <option value="uz">
+      Uzbek
+    </option>
+  
+    <option value="vi">
+      Vietnamese
+    </option>
+  
+    <option value="cy">
+      Welsh
+    </option>
+  </select>
+  <br>
+  <br>
+
+  <label for="month_font">Month Font</label>
+  <input type="text" id="month_font" name="month_font" size="30">
+  <br>
+  <br>
+
+  <label for="month_font_weight">Month Font Weight</label>
+  <input type="text" id="month_font_weight" name="month_font_weight" size="5">
+  <br>
+  <br>
+
+  <label for="external_css">WebFont CSS URL</label>
+  <input type="text" id="external_css" name="external_css" size="50">
+
+  <br>
+  <br>
+  <input type="submit" value="Generate">
+</form>
 <script language="javascript" src="draw.js"></script>
 <style>
 </style>


### PR DESCRIPTION
Locales from [Moment.js](http://momentjs.com/) (96 locales, more than 80 languages).
Customization form for locale, font, font weight and webfont CSS URL.
Form is hidden automatically on print.

![index html locale en month_font gloria hallelujah month_font_weight 400 external_css https 3a 2f 2ffonts googleapis com 2fcss 3 2016-01-03 14-26-10](https://cloud.githubusercontent.com/assets/181961/12078512/13243466-b226-11e5-8d22-1c23ccb92e3f.png)

Notes:
- Form submit uses GET, then params are parsed on the next page load. Also allows copying links for sharing.
- If external CSS is specified drawing is postponed until its load is completed.
- `lang` attribute of `body` is set to locale so the browser can choose the correct variants for CJK fonts.
- Default kerning is preserved but only used for the default pair `Bebas Neue Light` + `en`. Kerning for other pairs font+language can be added later.

Happy New Year!
